### PR TITLE
Fix plugin load on Apple Silicon macOS + a few small fixes

### DIFF
--- a/applyfilter.py
+++ b/applyfilter.py
@@ -10,8 +10,14 @@ email			: werner.macho@gmail.com
 """
 from builtins import range
 from builtins import object
-from scipy.signal import savgol_filter
 import numpy as np
+
+# scipy is imported lazily: the QGIS macOS bundle ships an x86_64-only
+# libgcc_s.1.1.dylib, so scipy.signal fails to dlopen on Apple Silicon.
+try:
+    from scipy.signal import savgol_filter
+except ImportError:
+    savgol_filter = None
 __author__ = 'werner.macho@gmail.com'
 __date__ = '2014/06/16'
 __copyright__ = 'Copyright 2014, Werner Macho'
@@ -25,6 +31,8 @@ class ApplyFilter(object):
 
     def smooth(self, orig_x, orig_y,window=9,polyorder=3,perc=75,p_window=5):
         try:
+            if savgol_filter is None:
+                raise ImportError("scipy not available")
             new_x = orig_x
             #new_y = medfilt(orig_y,p_window)
             new_y =[]

--- a/mutant.py
+++ b/mutant.py
@@ -71,9 +71,23 @@ class Mutant(object):
         self.iface.addDockWidget(Qt.LeftDockWidgetArea, self.mutantdockwidget)
         # self.mutantwidget.show()
 
+        # re-activate on project load if active in the previous session
+        self.iface.projectRead.connect(self.autoActivate)
+
+    def autoActivate(self):
+        if QSettings().value('plugins/mutant/active', False, type=bool) \
+                and self.mutantwidget.activeRasterLayers():
+            self.activateTool()
+
     def unload(self):
+        QSettings().setValue('plugins/mutant/active',
+                             self.mutantwidget.isActive)
         QSettings().setValue('plugins/mutant/mouseClick',
                              self.mutantwidget.plotOnMove.isChecked())
+        try:
+            self.iface.projectRead.disconnect(self.autoActivate)
+        except TypeError:
+            pass
         self.mutantdockwidget.close()
         self.deactivateTool()
         # remove dockwidget from iface

--- a/mutantwidget.py
+++ b/mutantwidget.py
@@ -380,7 +380,10 @@ class MutantWidget(QWidget, FORM_CLASS):
                 self.canvas.xyCoordinates .connect(self.printValue)
         else:
             self.toggleMutant.setCheckState(Qt.Unchecked)
-            self.canvas.layersChanged .disconnect(self.invalidatePlot)
+            try:
+                self.canvas.layersChanged.disconnect(self.invalidatePlot)
+            except TypeError:
+                pass  # not connected (e.g. re-entrant deactivation from catch_errors)
             try:
                 self.canvas.xyCoordinates.disconnect(self.printValue)
             except TypeError:
@@ -497,6 +500,7 @@ class MutantWidget(QWidget, FORM_CLASS):
         # And keep them in a dict() with key=layer.id()
 
         counter = 0
+        skipped_no_date = 0
         for layer in rasterlayers:
             layer_name = str(layer.name())
             layer_srs = layer.crs()
@@ -575,6 +579,7 @@ class MutantWidget(QWidget, FORM_CLASS):
                         layer_time = self.tracker.get_time_for_layer(layer)
 
                         if layer_time is None:
+                            skipped_no_date += 1
                             continue
                         else:
                             # pyqtgraph enabled convert date to epoch
@@ -609,7 +614,12 @@ class MutantWidget(QWidget, FORM_CLASS):
         self.values.sort(key=operator.itemgetter(1))
 
         if len(self.values) == 0:
-            self.labelStatus.setText(self.tr("No valid bands to display"))
+            if skipped_no_date > 0:
+                self.labelStatus.setText(self.tr(
+                    "Multi-temporal analysis is on, but no layer names "
+                    "contain a parseable date (see Time tab)"))
+            else:
+                self.labelStatus.setText(self.tr("No valid bands to display"))
 
         self.showValues(position)
 


### PR DESCRIPTION
  I ran into a few issues getting Mutant working on QGIS 3.44 (macOS, Apple Silicon) and fixed them along the way:

  - Lazy scipy import — the official macOS QGIS bundle ships an x86_64-only libgcc_s.1.1.dylib, so from scipy.signal import savgol_filter fails at import time on Apple Silicon and the whole plugin refuses to load. The import is now wrapped in try/except and smooth()
  falls back to the existing moving-average path when scipy isn't available.
  - Guarded signal disconnect in changeActive() — activating the tool with no raster layers loaded triggers a re-entrant deactivation from catch_errors(), which hit an unguarded layersChanged.disconnect() and raised TypeError, aborting activation halfway. Now guarded the
  same way as the xyCoordinates disconnect just below it.
  - Clearer status message — with multi-temporal analysis enabled, layers whose names don't contain a parseable date are silently skipped. If that leaves nothing to show, the status said "No valid bands to display", which sent me down the wrong path debugging. It now
  says MT analysis is on and no layer names have parseable dates.
  - Remember active state — the plugin now saves whether it was enabled on exit and re-activates automatically when a project with raster layers is opened, so you don't have to click the toolbar icon every session.

  Tested on QGIS 3.44 LTR / Qt 5.15 / Python 3.12 with the PyQtGraph backend.